### PR TITLE
Polish User Manual

### DIFF
--- a/input/01_introduction.pml
+++ b/input/01_introduction.pml
@@ -1,6 +1,6 @@
 [ch (id=introduction) [title Introduction]
 
-    This manual is about creating web articles and books with the [link url=https://www.pml-lang.dev/ text="Practical Markup Language (PML)"].
+    This manual is about creating web articles and books with the [link url=[u:get pml_website] text="Practical Markup Language (PML)"].
 
-    If you have questions or suggestions then please post a message on [link url=https://github.com/pml-lang/user-manual/discussions text="Github discussions"], or send an email to contact {at} pml-lang {dot} dev.
+    If you have questions or suggestions then please post a message on [link url=https://github.com/pml-lang/user-manual/discussions text="GitHub discussions"], or send an email to contact {at} pml-lang {dot} dev.
 ]

--- a/input/07_05_whitespace.pml
+++ b/input/07_05_whitespace.pml
@@ -57,7 +57,7 @@
                     this is text
                 code]
 
-                To preserve a sequence of several whitespace characters, the node [link url=https://www.pml-lang.dev/docs/reference_manual/index.html#node_sp text=sp] can be used to explicitly insert non-breaking spaces, and the node [link url=https://www.pml-lang.dev/docs/reference_manual/index.html#node_nl text=nl] can be used to explicitly insert new lines, e.g.:
+                To preserve a sequence of several whitespace characters, the node [link url=[u:get pml_website]/docs/reference_manual/index.html#node_sp text=sp] can be used to explicitly insert non-breaking spaces, and the node [link url=[u:get pml_website]/docs/reference_manual/index.html#node_nl text=nl] can be used to explicitly insert new lines, e.g.:
                 [code
                     this[sp][sp][sp][sp][sp]is[nl]text
                 code]
@@ -67,7 +67,7 @@
                     text
                 code]
 
-                Moreover, the [link url=https://www.pml-lang.dev/docs/reference_manual/index.html#node_monospace text=monospace] node can be used to insert a block of text in which whitespace is preserved (similar to the [c pre] tag in HTML):
+                Moreover, the [link url=[u:get pml_website]/docs/reference_manual/index.html#node_monospace text=monospace] node can be used to insert a block of text in which whitespace is preserved (similar to the [c pre] tag in HTML):
                 [code
                     [monospace
                     this     is

--- a/input/index.pml
+++ b/input/index.pml
@@ -1,15 +1,15 @@
 [doc [title PML User Manual]
 
+    [u:set images_dir=images]
+    [u:set pml_website=https://www.pml-lang.dev]
+
     [table
         [tr [tc [b PML Version]][tc 3.1.0 2022-10-03]]
         [tr [tc [b License]][tc [link url=https://creativecommons.org/licenses/by-nd/4.0/ text="CC BY-ND 4.0"]]]
         [tr [tc [b Author and Copyright]][tc Christian Neumanns]]
-        [tr [tc [b Website]][tc [link url=https://www.pml-lang.dev/]]]
-        [tr [tc [b PML Markup Code]][tc [link url=https://github.com/pml-lang/user-manual text=Github]]]
+        [tr [tc [b Website]][tc [link url=[u:get pml_website]]]]
+        [tr [tc [b PML Markup Code]][tc [link url=https://github.com/pml-lang/user-manual text=GitHub]]]
     ]
-
-    [u:set images_dir=images]
-    [u:set pml_website=https://www.pml-lang.dev]
 
     [u:ins_file path=01_introduction.pml]
     [u:ins_file path=03_00_quick_start.pml]


### PR DESCRIPTION
* To enforce DRY maintenance and consistence, move definition of `pml_website` constant at start of `index.pml` and substitute all leftover occurrences of PML website URL with `[u:get pml_website]`.
* Fix all occurrences of "Github" to "GitHub".